### PR TITLE
Treemove

### DIFF
--- a/kagiso_smart_404/tests/test_utils.py
+++ b/kagiso_smart_404/tests/test_utils.py
@@ -4,8 +4,128 @@ from django.test import TestCase
 from wagtail.wagtailcore.models import Page
 
 from ..utils import (
+    page_slug,
+    slug_matches_one_page_exactly,
     suggest_page_from_misspelled_slug
 )
+
+
+def test_page_slug_gets_page_specific_slug_from_full_path():
+    assert page_slug('/news/') == 'news'
+    assert page_slug('/news') == 'news'
+    assert page_slug('news') == 'news'
+
+    assert page_slug('/news/myarticle/') == 'myarticle'
+    assert page_slug('/news/myarticle') == 'myarticle'
+    assert page_slug('news/myarticle') == 'myarticle'
+
+    assert page_slug('/favicon.ico') == 'favicon.ico'
+
+
+class SlugMatchesOnePageExactlyTest(TestCase):
+
+    def test_matching_slug_returns_single_page(self):
+        home_page = Page.objects.get(slug='home')
+        article = Page(
+            title='Workzone with Bridget Masinga',
+            slug='workzonewithbridgetmasinga',
+            live=True,
+            first_published_at=datetime.now()
+        )
+        home_page.add_child(instance=article)
+
+        result = slug_matches_one_page_exactly(
+            '/shows/workzonewithbridgetmasinga/', home_page)
+
+        assert result == article
+
+    def test_multiple_slug_depth(self):
+        home_page = Page.objects.get(slug='home')
+        article = Page(
+            title='Workzone with Bridget Masinga',
+            slug='workzonewithbridgetmasinga',
+            live=True,
+            first_published_at=datetime.now()
+        )
+        home_page.add_child(instance=article)
+
+        result = slug_matches_one_page_exactly(
+            '/test/post/page/shows/workzonewithbridgetmasinga/', home_page)
+
+        assert result == article
+
+    def test_multiple_articles_with_same_slug_returns_none(self):
+        home_page = Page.objects.get(slug='home')
+        article_index_one = Page(
+            title='First Index',
+            slug='firstindex'
+        )
+        article_index_two = Page(
+            title='Second Index',
+            slug='secondindex'
+        )
+        home_page.add_child(instance=article_index_one)
+        home_page.add_child(instance=article_index_two)
+
+        article_one = Page(
+            title='Workzone with Bridget Masinga',
+            slug='workzonewithbridgetmasinga'
+        )
+        article_two = Page(
+            title='Workzone with Bridget Masinga',
+            slug='workzonewithbridgetmasinga'
+        )
+
+        article_index_one.add_child(instance=article_one)
+        article_index_two.add_child(instance=article_two)
+
+        result = slug_matches_one_page_exactly(
+            '/shows/workzonewithbridgetmasinga/', home_page)
+
+        assert result is None
+
+    def test_no_matching_slug(self):
+        home_page = Page.objects.get(slug='home')
+        article = Page(
+            title='Workzone with Bridget Masinga',
+            slug='workzonewithbridgetmasinga'
+        )
+        home_page.add_child(instance=article)
+
+        result = slug_matches_one_page_exactly(
+            '/post/noresult/', home_page)
+
+        assert result is None
+
+    def test_slug_scopes_to_site(self):
+        home_page = Page.objects.get(slug='home')
+        article_index_one = Page(
+            title='First Index',
+            slug='firstindex'
+        )
+        article_index_two = Page(
+            title='Second Index',
+            slug='secondindex'
+        )
+        home_page.add_child(instance=article_index_one)
+        home_page.add_child(instance=article_index_two)
+
+        article_one = Page(
+            title='Article One',
+            slug='articleone'
+        )
+        article_two = Page(
+            title='Article Two',
+            slug='articletwo'
+        )
+
+        article_index_one.add_child(instance=article_one)
+        article_index_two.add_child(instance=article_two)
+
+        result = slug_matches_one_page_exactly(
+            '/shows/articleone/', article_index_two)
+
+        assert result is None
 
 
 class SuggestPageFromMisspelledSlugTest(TestCase):
@@ -13,7 +133,7 @@ class SuggestPageFromMisspelledSlugTest(TestCase):
     def test_no_similar_slugs_returns_empty_array(self):
         home_page = Page.objects.get(slug='home')
         result = suggest_page_from_misspelled_slug(
-            '/no-such-page/', home_page)
+            '/nosuchpage/', home_page)
 
         assert result == []
 
@@ -21,14 +141,14 @@ class SuggestPageFromMisspelledSlugTest(TestCase):
         home_page = Page.objects.get(slug='home')
         article = Page(
             title='Workzone with Bridget Masinga',
-            slug='workzone-with-bridget-masinga',
+            slug='workzonewithbridgetmasinga',
             live=True,
             first_published_at=datetime.now()
         )
         home_page.add_child(instance=article)
 
         result = suggest_page_from_misspelled_slug(
-            '/workzon-bridget-masing/', home_page)
+            '/workzonbridgetmasing/', home_page)
 
         assert article in result
 
@@ -36,13 +156,13 @@ class SuggestPageFromMisspelledSlugTest(TestCase):
         home_page = Page.objects.get(slug='home')
         better_matching_article = Page(
             title='Workzone with Bridget Masinga',
-            slug='workzone-with-bridget-masinga',
+            slug='workzonewithbridgetmasinga',
             live=True,
             first_published_at=datetime.now()
         )
         poorer_matching_article = Page(
             title='Bridget Masinga',
-            slug='bridget-masinga',
+            slug='bridgetmasinga',
             live=True,
             first_published_at=datetime.now()
         )
@@ -50,44 +170,42 @@ class SuggestPageFromMisspelledSlugTest(TestCase):
         home_page.add_child(instance=poorer_matching_article)
 
         result = suggest_page_from_misspelled_slug(
-            '/workzon-bridget-masing/', home_page)
+            '/workzonbridgetmasing/', home_page)
 
         assert better_matching_article in result
 
     def test_multiple_matches_returns_max_3_top_matches(self):
         home_page = Page.objects.get(slug='home')
-        ok_match_1 = Page(
+        match_1 = Page(
             title='Bridget Masinga',
-            slug='bridget-masinga',
+            slug='bridgetmasinga',
             live=True,
             first_published_at=datetime.now()
         )
-        ok_match_2 = Page(
-            title='Bridget Masinga Again',
-            slug='bridget-masinga-again',
+        match_2 = Page(
+            title='Bridget Masinga1',
+            slug='bridgetmasinga1',
             live=True,
             first_published_at=datetime.now()
         )
-        ok_match_3 = Page(
-            title='More Bridget Masinga',
-            slug='more-bridget-masinga',
+        match_3 = Page(
+            title='Bridget Masinga2',
+            slug='bridgetmasinga2',
             live=True,
             first_published_at=datetime.now()
         )
-        # If slicing is commented out this result is returned for a slug '/bridget'! # noqa
-        poorer_match = Page(
-            title='Bridge Building',
-            slug='bridge-building',
+        match_4 = Page(
+            title='Bridget Masinga3',
+            slug='bridgetmasinga3',
             live=True,
             first_published_at=datetime.now()
         )
-        home_page.add_child(instance=ok_match_1)
-        home_page.add_child(instance=ok_match_2)
-        home_page.add_child(instance=ok_match_3)
-        home_page.add_child(instance=poorer_match)
+        home_page.add_child(instance=match_1)
+        home_page.add_child(instance=match_2)
+        home_page.add_child(instance=match_3)
+        home_page.add_child(instance=match_4)
 
         result = suggest_page_from_misspelled_slug(
             '/bridget', home_page)
 
         assert len(result) == 3
-        assert poorer_match not in result

--- a/kagiso_smart_404/utils.py
+++ b/kagiso_smart_404/utils.py
@@ -1,17 +1,44 @@
 from wagtail.wagtailcore.models import Page
 
 
+def page_slug(slug):
+    # Full slug might be /news/sports/somesportsarticle/
+    # The page slug is therefore `somesportsarticle`
+    slugs = slug.split('/')
+    print(slugs)
+
+    # Remove all empty strings
+    # '/news/article' => ['', 'news', 'article', '']
+    slugs = list(filter(None, slugs))
+
+    page_slug = slugs[-1]
+    return page_slug
+
+
+def slug_matches_one_page_exactly(slug, root_page):
+    slug = page_slug(slug)
+    try:
+        result = Page.objects.descendant_of(root_page).get(
+            slug=slug,
+            live=True,
+            first_published_at__isnull=False
+        )
+        return result
+    except (Page.MultipleObjectsReturned, Page.DoesNotExist):
+        return None
+
+
 def suggest_page_from_misspelled_slug(slug, root_page):
     root_path = root_page.path
     root_path_len = len(root_path)
 
     sql = '''SELECT p.*, similarity(slug, %(slug)s) AS similarity
-    FROM wagtailcore_page p
-    WHERE live = true
-    AND first_published_at IS NOT NULL
-    AND substring(path FOR %(root_path_len)s) = %(root_path)s
-    AND slug %% %(slug)s
-    ORDER BY similarity DESC
+             FROM wagtailcore_page p
+             WHERE live = true
+                 AND first_published_at IS NOT NULL
+                 AND substring(path FOR %(root_path_len)s) = %(root_path)s
+                 AND slug %% %(slug)s
+             ORDER BY similarity DESC
     '''
     data = {
         'slug': slug,

--- a/kagiso_smart_404/utils.py
+++ b/kagiso_smart_404/utils.py
@@ -15,6 +15,13 @@ def page_slug(slug):
     return page_slug
 
 
+# This function is useful if a content person has moved a page
+# around the tree, but hasn't changed the page slug
+# eg: /news/proteas-win-again/ => /sport/proteas-win-again/
+# This is quite a common scenario
+#
+# So we see if there is another page in the db the db that matches that exact
+# page slug, if so we assume that is the 'missing' page.
 def slug_matches_one_page_exactly(slug, root_page):
     slug = page_slug(slug)
     try:

--- a/kagiso_smart_404/utils.py
+++ b/kagiso_smart_404/utils.py
@@ -5,7 +5,6 @@ def page_slug(slug):
     # Full slug might be /news/sports/somesportsarticle/
     # The page slug is therefore `somesportsarticle`
     slugs = slug.split('/')
-    print(slugs)
 
     # Remove all empty strings
     # '/news/article' => ['', 'news', 'article', '']

--- a/kagiso_smart_404/utils.py
+++ b/kagiso_smart_404/utils.py
@@ -15,7 +15,8 @@ def page_slug(slug):
 
 
 # This function is useful if a content person has moved a page
-# around the tree, but hasn't changed the page slug
+# around the tree, as the page url will change due to the parent node changing
+# e.g. from 'News' to 'Sport', but the slug hasn't changed
 # eg: /news/proteas-win-again/ => /sport/proteas-win-again/
 # This is quite a common scenario
 #

--- a/kagiso_smart_404/views.py
+++ b/kagiso_smart_404/views.py
@@ -13,6 +13,8 @@ def not_found(request):  # pragma: no cover
 
     suggested_pages = suggest_page_from_misspelled_slug(slug, root_page)
 
+    # Has a content person moved a page around the tree with the page slug
+    # remaining as per before, if so redirect to page with matching slug
     exact_match = slug_matches_one_page_exactly(slug, root_page)
     if exact_match:
         return HttpResponsePermanentRedirect(redirect_to=exact_match.url)

--- a/kagiso_smart_404/views.py
+++ b/kagiso_smart_404/views.py
@@ -2,6 +2,7 @@ from django.http import HttpResponsePermanentRedirect
 from django.shortcuts import render
 
 from .utils import (
+    slug_matches_one_page_exactly,
     suggest_page_from_misspelled_slug
 )
 
@@ -12,9 +13,9 @@ def not_found(request):  # pragma: no cover
 
     suggested_pages = suggest_page_from_misspelled_slug(slug, root_page)
 
-    if len(suggested_pages) == 1:
-        intended_url = suggested_pages[0].url
-        return HttpResponsePermanentRedirect(redirect_to=intended_url)
+    exact_match = slug_matches_one_page_exactly(slug, root_page)
+    if exact_match:
+        return HttpResponsePermanentRedirect(redirect_to=exact_match.url)
 
     data = {'suggested_pages': suggested_pages}
     return render(request, '404.html', data, status=404)

--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,10 @@ wagtail==1.4.3
 psycopg2
 
 flake8
+flake8-blind-except
 flake8-import-order
+flake8-print
+flake8-quotes
 pep8-naming
 
 pytest-django

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,12 +10,15 @@ django-taggit==0.18.0     # via wagtail
 django-treebeard==3.0     # via wagtail
 django==1.8.12
 djangorestframework==3.3.2  # via wagtail
+flake8-blind-except==0.1.0
 flake8-import-order==0.6.1
+flake8-print==2.0.2
+flake8-quotes==0.3.0
 flake8==2.5.2
 html5lib==0.9999999       # via wagtail
 mccabe==0.4.0             # via flake8
 pep8-naming==0.3.3
-pep8==1.7.0               # via flake8, flake8-import-order
+pep8==1.7.0               # via flake8, flake8-import-order, flake8-quotes
 Pillow==3.1.1             # via wagtail
 psycopg2==2.6.1
 py==1.4.31                # via pytest
@@ -27,3 +30,7 @@ six==1.10.0               # via html5lib
 Unidecode==0.4.19         # via wagtail
 wagtail==1.4.3
 Willow==0.3               # via wagtail
+
+# The following packages are commented out because they are
+# considered to be unsafe in a requirements file:
+# setuptools                # via flake8-blind-except

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='kagiso_smart_404',
-    version='1.2.0',
+    version='1.3.0',
     author='Kagiso Media',
     author_email='development@kagiso.io',
     description='Kagiso Smart 404',


### PR DESCRIPTION
Added back code to handle pages being moved around tree but without page slug changing. Added comments to explain why this code is necessary to handle this special condition, as it is not obvious.

Useful if a content person has moved a page around the tree, but hasn't changed the page slug
eg: /news/proteas-win-again/ => /sport/proteas-win-again/
